### PR TITLE
ci: release workflow に safe-chain を追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
       -
+        name: Install safe-chain
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+      -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:


### PR DESCRIPTION
## 概要
GitHub Actions の release ワークフローに AikidoSec/safe-chain のインストール手順を追加しました。

## 変更内容
- `.github/workflows/release.yml` に `Install safe-chain` ステップを追加
- Go セットアップ後、GoReleaser 実行前に safe-chain を導入する構成に変更

## 補足
- 依存ライブラリやアプリケーションのバージョン更新は行っていません
- CI/ワークフロー設定の変更のみです
