### PR TITLE
revert: safe-chain 追加を差し戻し

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,6 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
       -
-        name: Install safe-chain
-        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
-      -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:


### PR DESCRIPTION
## 概要
PR #13（`ci: release workflow に safe-chain を追加`）の変更をrevertします。

## 背景
- `safe-chain` は現状 npm / PyPI 系向けで、Go Modules には未対応
- 本リポジトリ（Go）の release workflow では実効性がないため、設定を元に戻します

## 変更内容
- `.github/workflows/release.yml` から `Install safe-chain` ステップを削除

## 備考
- これは設定差し戻しのみで、アプリ本体コードの変更はありません
