### PR TITLE
ci: releaseワークフローにsafe-chain導入

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
       -
+        name: Install safe-chain
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+      -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:


### PR DESCRIPTION
## 概要
- `release.yml` に safe-chain のインストールステップを追加しました。

## 変更内容
- `actions/setup-go` の直後に `Install safe-chain` ステップを追加
- インストールコマンド:
  - `curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci`

## 確認
- 変更対象は `.github/workflows/release.yml` のみです（CIワークフロー変更のみ）
- 依存関係やライブラリバージョンの更新は行っていません
- `npm ci` を含むワークフローはこのリポジトリには存在しないため、分割対応は不要でした
