### PR TITLE
revert: Go未対応のためsafe-chain導入を取り消し

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,6 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
       -
-        name: Install safe-chain
-        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
-      -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:


### PR DESCRIPTION
## 概要
Goリポジトリでは safe-chain が未対応のため、#15 で導入した release ワークフロー上の safe-chain ステップをrevertします。

## 変更内容
- `Revert "ci: releaseワークフローにsafe-chain導入 (#15)"`
- 対象ファイル: `.github/workflows/release.yml`（safe-chain関連の3行を削除）

## 確認事項
- 変更は CI ワークフローのみ
- 依存関係/ライブラリ更新なし
